### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/rbazi/447eebb7-8a39-4377-8be4-3b57fcb69c00/e4406a49-2ad1-4679-80f6-56a8f732713f/_apis/work/boardbadge/813efcdd-aea2-4865-899b-039e7893d986)](https://dev.azure.com/rbazi/447eebb7-8a39-4377-8be4-3b57fcb69c00/_boards/board/t/e4406a49-2ad1-4679-80f6-56a8f732713f/Microsoft.RequirementCategory)
 # testme


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#613](https://dev.azure.com/rbazi/447eebb7-8a39-4377-8be4-3b57fcb69c00/_workitems/edit/613). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.